### PR TITLE
python: release: artifacts are in python/dist

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -55,6 +55,7 @@ jobs:
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: python/dist
+          if-no-files-found: error
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -87,6 +88,7 @@ jobs:
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: python/dist
+          if-no-files-found: error
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -115,6 +117,7 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: python/dist
+          if-no-files-found: error
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -142,6 +145,7 @@ jobs:
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: python/dist
+          if-no-files-found: error
 
   release:
     name: Release

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -86,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   release:
     name: Release


### PR DESCRIPTION
The wheels wheren’t uploaded (https://github.com/osrd-project/liblrs/actions/runs/11342006817/job/31541481837) :

`Warning: No files were found with the provided path: dist. No artifacts will be uploaded.`

This failed just with a warning, not an error.

Later, https://github.com/osrd-project/liblrs/actions/runs/11342006817/job/31541648989 the wheels couldn’t be found resulting in an error