### PR TITLE
publishing: python artefacts are not downloaded in ./python

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -214,4 +214,3 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
-          working-directory: './python'


### PR DESCRIPTION
sorry for the noise