### PR TITLE
Cleaner constructor

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -301,11 +301,16 @@ pub struct LrmProjection {
 
 impl From<&liblrs::lrm_scale::Anchor> for Anchor {
     fn from(value: &liblrs::lrm_scale::Anchor) -> Self {
+        let name = match value {
+            liblrs::lrm_scale::Anchor::Named(value) => value.name.clone(),
+            liblrs::lrm_scale::Anchor::Unnamed(_) => "-".to_owned(),
+        };
+
         Self {
-            name: value.clone().id.unwrap_or_else(|| "-".to_owned()),
-            position: value.point.map(|p| p.into()),
-            curve_position: value.curve_position,
-            scale_position: value.scale_position,
+            name,
+            position: value.point().map(|p| p.into()),
+            curve_position: value.curve_position(),
+            scale_position: value.scale_position(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@ fn read_and_write_lrs() {
 
     let buffer = builder.build_data(properties!("source" => "example"));
     let lrs = lrs::Lrs::<SphericalLineStringCurve>::from_bytes(buffer).unwrap();
-    let anchor = &lrs.lrms[0].scale.anchors[0];
-    assert_eq!(anchor.id.as_ref().unwrap(), "12");
+    match &lrs.lrms[0].scale.anchors[0] {
+        lrm_scale::Anchor::Named(anchor) => assert_eq!(anchor.name, "12"),
+        _ => unreachable!(),
+    }
 }

--- a/src/lrs.rs
+++ b/src/lrs.rs
@@ -295,7 +295,7 @@ impl<CurveImpl: Curve> Lrs<CurveImpl> {
                         .unwrap_or_else(|| project(&anchor, curve));
 
                     match anchor.name() {
-                        Some(name) => Anchor::new(
+                        Some(name) => Anchor::new_named(
                             name,
                             scale_position,
                             curve_position,

--- a/src/lrs_ext.rs
+++ b/src/lrs_ext.rs
@@ -99,6 +99,6 @@ impl ExtLrs {
 
     /// [`Properties`] for a given anchor
     pub fn anchor_properties(&self, lrm_index: usize, anchor_index: usize) -> &Properties {
-        &self.lrs.lrms[lrm_index].scale.anchors[anchor_index].properties
+        self.lrs.lrms[lrm_index].scale.anchors[anchor_index].properties()
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -114,11 +114,16 @@ pub struct Anchor {
 
 impl From<&liblrs::lrm_scale::Anchor> for Anchor {
     fn from(value: &liblrs::lrm_scale::Anchor) -> Self {
+        let name = match value {
+            liblrs::lrm_scale::Anchor::Named(value) => value.name.clone(),
+            liblrs::lrm_scale::Anchor::Unnamed(_) => "-".to_owned(),
+        };
+
         Self {
-            name: value.clone().id.unwrap_or_else(|| "-".to_owned()),
-            position: value.point.map(|p| p.into()),
-            curve_position: value.curve_position,
-            scale_position: value.scale_position,
+            name,
+            position: value.point().map(|p| p.into()),
+            curve_position: value.curve_position(),
+            scale_position: value.scale_position(),
         }
     }
 }


### PR DESCRIPTION
Re-organizes a bit the code by implementing the `From` trait on some objects when converting from flatbuffers to rust objects.

This is still work in progress, but it’s already a bit better