### PR TITLE
chore: add other generated files to 'gitattributes'

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
 src/lrs_generated.rs linguist-generated=true
+python/liblrs_python.pyi linguist-generated=true


### PR DESCRIPTION
It allows Github to not display the entire diff which, in most case, is not relevant. It is still possible to see it by unfolding the file in the diff view if necessary.