### PR TITLE
python: do not build for macOS13, add macos15

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -141,9 +141,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
+            target: aarch64
+          - runner: macos-15
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/